### PR TITLE
Reusable Relay objects, and client-related logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+Changes from 0.1.0-dev:
+
+- Relay now typehints on _RequestInterface_ instead of _ServerRequestInterface_. Because the latter extends the former, this means _Relay_ can now be used for HTTP client logic as well.
+
+- You should now create the _Relay_ object from the _RelayBuilder_ instead of creating it directly. If you create it directly, you will need to pass a _RunnerFactory_ to the constructor instead of a `$resolver`.
+
+- _Relay_ objects are now reusable; i.e., they will reuse the $queue if you dispatch through them again.
+
+- If you know you want to dispatch the middleware queue only once, you can save some minor overhead by instantiating a _Runner_ instead of a _Relay_. E.g., `$runner = new Runner($queue, $resolver); $response = $runner($request, $response);`.

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -56,10 +56,9 @@ class Relay
      * @return Response
      *
      */
-    public function __invoke()
+    public function __invoke(Request $request, Response $response)
     {
         $runner = $this->runnerFactory->newInstance();
-        $params = func_get_args();
-        return call_user_func_array($runner, $params);
+        return $runner($request, $response);
     }
 }

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -56,9 +56,10 @@ class Relay
      * @return Response
      *
      */
-    public function __invoke(Request $request, Response $response)
+    public function __invoke()
     {
         $runner = $this->runnerFactory->newInstance();
-        return $runner($request, $response);
+        $params = func_get_args();
+        return call_user_func_array($runner, $params);
     }
 }

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -10,7 +10,7 @@
  */
 namespace Relay;
 
-use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
 /**
@@ -24,83 +24,41 @@ class Relay
 {
     /**
      *
-     * The middleware queue.
+     * A factory to create Runner objects.
      *
-     * @var array
-     *
-     */
-    protected $queue = [];
-
-    /**
-     *
-     * A callable to convert queue entries to callables.
-     *
-     * @var callable
+     * @var RunnerFactory
      *
      */
-    protected $resolver;
+    protected $runnerFactory;
 
     /**
      *
      * Constructor.
      *
-     * @param array $queue The middleware queue.
-     *
-     * @param callable $resolver Converts queue entries to callables.
+     * @param RunnerFactory $runnerFactory A factory to create Runner objects.
      *
      * @return self
      *
      */
-    public function __construct(array $queue, callable $resolver = null)
+    public function __construct(RunnerFactory $runnerFactory)
     {
-        $this->queue = $queue;
-        $this->resolver = $resolver;
+        $this->runnerFactory = $runnerFactory;
     }
 
     /**
      *
-     * Calls the next entry in the queue.
+     * Starts a Relay Runner.
      *
-     * @param Request $request The incoming request.
+     * @param Request $request The request.
      *
-     * @param Response $response The outgoing response.
+     * @param Response $response The response.
      *
      * @return Response
      *
      */
     public function __invoke(Request $request, Response $response)
     {
-        $entry = array_shift($this->queue);
-        $middleware = $this->resolve($entry);
-        return $middleware($request, $response, $this);
-    }
-
-    /**
-     *
-     * Converts a queue entry to a callable, using the resolver if present.
-     *
-     * @param mixed $entry The queue entry.
-     *
-     * @return callable
-     *
-     */
-    protected function resolve($entry)
-    {
-        if (! $entry) {
-            // the default callable when the queue is empty
-            return function (
-                Request $request,
-                Response $response,
-                callable $next
-            ) {
-                return $response;
-            };
-        }
-
-        if (! $this->resolver) {
-            return $entry;
-        }
-
-        return call_user_func($this->resolver, $entry);
+        $runner = $this->runnerFactory->newInstance();
+        return $runner($request, $response);
     }
 }

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 
 /**
  *
- * A PSR-7 middleware dispatcher.
+ * A reusable PSR-7 middleware dispatcher.
  *
  * @package Relay.Relay
  *

--- a/src/RelayBuilder.php
+++ b/src/RelayBuilder.php
@@ -24,6 +24,15 @@ class RelayBuilder
 {
     /**
      *
+     * A callable to convert queue entries to callables.
+     *
+     * @var callable
+     *
+     */
+    protected $resolver;
+
+    /**
+     *
      * Constructor.
      *
      * @param callable $resolver A resolver to convert queue entries to
@@ -39,17 +48,20 @@ class RelayBuilder
 
     /**
      *
-     * Returns a new Pipline instance.
+     * Returns a new Relay instance.
      *
      * @param array|ArrayObject|GetArrayCopyInterface $queue The queue for the
-     * Relay.
+     * Relay Runner object.
      *
      * @return Relay
      *
      */
     public function newInstance($queue)
     {
-        return new Relay($this->getArray($queue), $this->resolver);
+        return new Relay(new RunnerFactory(
+            $this->getArray($queue),
+            $this->resolver
+        ));
     }
 
     /**

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 
 /**
  *
- * A PSR-7 middleware dispatcher.
+ * A single-use PSR-7 middleware dispatcher.
  *
  * @package Relay.Relay
  *

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -68,13 +68,11 @@ class Runner
      * @return Response
      *
      */
-    public function __invoke()
+    public function __invoke(Request $request, Response $response)
     {
         $entry = array_shift($this->queue);
         $middle = $this->resolve($entry);
-        $params = func_get_args();
-        $params[] = $this;
-        return call_user_func_array($middle, $params);
+        return $middle($request, $response, $this);
     }
 
     /**

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -68,11 +68,13 @@ class Runner
      * @return Response
      *
      */
-    public function __invoke(Request $request, Response $response)
+    public function __invoke()
     {
         $entry = array_shift($this->queue);
-        $middleware = $this->resolve($entry);
-        return $middleware($request, $response, $this);
+        $middle = $this->resolve($entry);
+        $params = func_get_args();
+        $params[] = $this;
+        return call_user_func_array($middle, $params);
     }
 
     /**
@@ -87,7 +89,8 @@ class Runner
     protected function resolve($entry)
     {
         if (! $entry) {
-            // the default callable when the queue is empty
+            // the default callable when the queue is empty.
+            // different for client and server though. :-/
             return function (
                 Request $request,
                 Response $response,

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ *
+ * This file is part of Relay for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @copyright 2015, Paul M. Jones
+ *
+ */
+namespace Relay;
+
+use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ *
+ * A PSR-7 middleware dispatcher.
+ *
+ * @package Relay.Relay
+ *
+ */
+class Runner
+{
+    /**
+     *
+     * The middleware queue.
+     *
+     * @var array
+     *
+     */
+    protected $queue = [];
+
+    /**
+     *
+     * A callable to convert queue entries to callables.
+     *
+     * @var callable
+     *
+     */
+    protected $resolver;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param array $queue The middleware queue.
+     *
+     * @param callable $resolver Converts queue entries to callables.
+     *
+     * @return self
+     *
+     */
+    public function __construct(array $queue, callable $resolver = null)
+    {
+        $this->queue = $queue;
+        $this->resolver = $resolver;
+    }
+
+    /**
+     *
+     * Calls the next entry in the queue.
+     *
+     * @param Request $request The request.
+     *
+     * @param Response $response The response.
+     *
+     * @return Response
+     *
+     */
+    public function __invoke(Request $request, Response $response)
+    {
+        $entry = array_shift($this->queue);
+        $middleware = $this->resolve($entry);
+        return $middleware($request, $response, $this);
+    }
+
+    /**
+     *
+     * Converts a queue entry to a callable, using the resolver if present.
+     *
+     * @param mixed $entry The queue entry.
+     *
+     * @return callable
+     *
+     */
+    protected function resolve($entry)
+    {
+        if (! $entry) {
+            // the default callable when the queue is empty
+            return function (
+                Request $request,
+                Response $response,
+                callable $next
+            ) {
+                return $response;
+            };
+        }
+
+        if (! $this->resolver) {
+            return $entry;
+        }
+
+        return call_user_func($this->resolver, $entry);
+    }
+}

--- a/src/RunnerFactory.php
+++ b/src/RunnerFactory.php
@@ -1,0 +1,18 @@
+<?php
+namespace Relay;
+
+class RunnerFactory
+{
+    public function __construct(array $queue, $resolver)
+    {
+        $this->queue = $queue;
+        $this->resolver = $resolver;
+    }
+
+    // @TODO Note that the resolver will re-resolve each queue entry for the
+    // Runner, since the queue is re-injected from the factory property by copy.
+    public function newInstance()
+    {
+        return new Runner($this->queue, $this->resolver);
+    }
+}

--- a/tests/FakeMiddleware.php
+++ b/tests/FakeMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 namespace Relay;
 
-use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 
 class FakeMiddleware

--- a/tests/RelayBuilderTest.php
+++ b/tests/RelayBuilderTest.php
@@ -6,37 +6,37 @@ use InvalidArgumentException;
 
 class RelayBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    protected $relayFactory;
+    protected $relayBuilder;
 
     protected function setUp()
     {
-        $this->relayFactory = new RelayBuilder();
+        $this->relayBuilder = new RelayBuilder();
     }
 
     public function testArray()
     {
         $queue = [];
-        $relay = $this->relayFactory->newInstance($queue);
+        $relay = $this->relayBuilder->newInstance($queue);
         $this->assertInstanceOf('Relay\Relay', $relay);
     }
 
     public function testArrayObject()
     {
         $queue = new ArrayObject([]);
-        $relay = $this->relayFactory->newInstance($queue);
+        $relay = $this->relayBuilder->newInstance($queue);
         $this->assertInstanceOf('Relay\Relay', $relay);
     }
 
     public function testGetArrayCopyInterface()
     {
         $queue = new FakeQueue();
-        $relay = $this->relayFactory->newInstance($queue);
+        $relay = $this->relayBuilder->newInstance($queue);
         $this->assertInstanceOf('Relay\Relay', $relay);
     }
 
     public function testInvalidArgument()
     {
         $this->setExpectedException('InvalidArgumentException');
-        $this->relayFactory->newInstance('bad argument');
+        $this->relayBuilder->newInstance('bad argument');
     }
 }


### PR DESCRIPTION
This BC-breaking PR opens up Relay to client-related usage as well as server-related usage.

The central break is that what used to be the _Relay_ class is now the _Runner_ class, and a replacement _Relay_ class now acts as reusable wrapper around Runner instances.  That means the new _Relay_ class is instantiated differently.
- Relay now typehints on _RequestInterface_ instead of _ServerRequestInterface_. Because the latter extends the former, this means _Relay_ can now be used for HTTP client logic as well.
- You should now create the _Relay_ object from the _RelayBuilder_ instead of creating it directly. If you create it directly, you will need to pass a _RunnerFactory_ to the constructor instead of a `$resolver`.
- _Relay_ objects are now reusable; i.e., they will reuse the $queue if you dispatch through them again.
- If you know you want to dispatch the middleware queue only once, you can save some minor overhead by instantiating a _Runner_ instead of a _Relay_. E.g., `$runner = new Runner($queue, $resolver); $response = $runner($request, $response);`.
