### PR TITLE
Add ReusableRelay

### DIFF
--- a/src/RelayFactory.php
+++ b/src/RelayFactory.php
@@ -1,0 +1,16 @@
+<?php
+namespace Relay;
+
+class RelayFactory
+{
+    public function __construct(array $queue, $resolver = null)
+    {
+        $this->queue = $queue;
+        $this->resolver = $resolver;
+    }
+
+    public function newInstance()
+    {
+        return new Relay($this->queue, $this->resolver);
+    }
+}

--- a/src/RelayFactory.php
+++ b/src/RelayFactory.php
@@ -3,6 +3,9 @@ namespace Relay;
 
 class RelayFactory
 {
+    protected $queue;
+    protected $resolver;
+
     public function __construct(array $queue, $resolver = null)
     {
         $this->queue = $queue;

--- a/src/ReusableRelay.php
+++ b/src/ReusableRelay.php
@@ -6,6 +6,8 @@ use Psr\Http\Message\ResponseInterface as Response;
 
 class ReusableRelay
 {
+    protected $relayFactory;
+
     public function __construct(RelayFactory $relayFactory)
     {
         $this->relayFactory = $relayFactory;

--- a/src/ReusableRelay.php
+++ b/src/ReusableRelay.php
@@ -1,0 +1,19 @@
+<?php
+namespace Relay;
+
+use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+class ReusableRelay
+{
+    public function __construct(RelayFactory $relayFactory)
+    {
+        $this->relayFactory = $relayFactory;
+    }
+
+    public function __invoke(Request $request, Response $response)
+    {
+        $relay = $this->relayFactory->newInstance();
+        return $relay($request, $response);
+    }
+}

--- a/src/ReusableRelayBuilder.php
+++ b/src/ReusableRelayBuilder.php
@@ -15,10 +15,15 @@ class ReusableRelayBuilder
 
     public function newInstance($queue)
     {
-        return new ReusableRelay(new RelayFactory(
+        return new ReusableRelay($this->newRelayFactory($queue));
+    }
+
+    protected function newRelayFactory($queue)
+    {
+        return new RelayFactory(
             $this->getArray($queue),
             $this->resolver
-        ));
+        );
     }
 
     protected function getArray($queue)

--- a/src/ReusableRelayBuilder.php
+++ b/src/ReusableRelayBuilder.php
@@ -1,0 +1,39 @@
+<?php
+namespace Relay;
+
+use ArrayObject;
+use InvalidArgumentException;
+
+class ReusableRelayBuilder
+{
+    protected $resolver;
+
+    public function __construct($resolver = null)
+    {
+        $this->resolver = $resolver;
+    }
+
+    public function newInstance($queue)
+    {
+        return new ReusableRelay(new RelayFactory(
+            $this->getArray($queue),
+            $this->resolver
+        ));
+    }
+
+    protected function getArray($queue)
+    {
+        if (is_array($queue)) {
+            return $queue;
+        }
+
+        $getArrayCopy = $queue instanceof GetArrayCopyInterface
+            || $queue instanceof ArrayObject;
+
+        if ($getArrayCopy) {
+            return $queue->getArrayCopy();
+        }
+
+        throw new InvalidArgumentException();
+    }
+}

--- a/tests/ReusableRelayTest.php
+++ b/tests/ReusableRelayTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Relay;
+
+use Zend\Diactoros\ServerRequestFactory;
+use Zend\Diactoros\Response;
+
+class ReusableRelayTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        FakeMiddleware::$count = 0;
+
+        $queue[] = new FakeMiddleware();
+        $queue[] = new FakeMiddleware();
+        $queue[] = new FakeMiddleware();
+
+        $builder = new ReusableRelayBuilder();
+        $relay = $builder->newInstance($queue);
+
+        // relay once
+        $response = $relay(
+            ServerRequestFactory::fromGlobals(),
+            new Response()
+        );
+        $actual = (string) $response->getBody();
+        $this->assertSame('123456', $actual);
+
+        // relay again
+        $response = $relay(
+            ServerRequestFactory::fromGlobals(),
+            new Response()
+        );
+        $actual = (string) $response->getBody();
+        $this->assertSame('789101112', $actual);
+    }
+}


### PR DESCRIPTION
This is an interim PR to add the ReusableRelay functionality without disturbing the previous single-use Relay functionality.

The steps after this would be to:
1. Rename Relay to Runner,
2. Rename RelayFactory to RunnerFactory,
3. Rename ReusableRelay to Relay,
4. Remove the existing RelayBuilder, and
5. Rename ReusableRelayBuilder to RelayBuilder.

The renames have the effect of making a Relay reusable by default, and the Runner the single-use dispatcher that the Relay uses.
