### PR TITLE
Fix array detection bug in builder

### DIFF
--- a/src/RelayBuilder.php
+++ b/src/RelayBuilder.php
@@ -12,6 +12,7 @@ namespace Relay;
 
 use ArrayObject;
 use InvalidArgumentException;
+use Traversable;
 
 /**
  *
@@ -50,7 +51,7 @@ class RelayBuilder
      *
      * Creates a new Relay with the specified queue for its Runner objects.
      *
-     * @param array|ArrayObject|GetArrayCopyInterface $queue The queue
+     * @param array|Traversable|GetArrayCopyInterface $queue The queue
      * specification.
      *
      * @return Relay
@@ -65,7 +66,7 @@ class RelayBuilder
      *
      * Creates a new RunnerFactory with a specified queue.
      *
-     * @param array|ArrayObject|GetArrayCopyInterface $queue The queue
+     * @param array|Traversable|GetArrayCopyInterface $queue The queue
      * specification.
      *
      * @return RunnerFactory
@@ -83,7 +84,7 @@ class RelayBuilder
      *
      * Converts the queue specification to an array.
      *
-     * @param array|ArrayObject|GetArrayCopyInterface $queue The queue
+     * @param array|Traversable|GetArrayCopyInterface $queue The queue
      * specification.
      *
      * @return array
@@ -100,6 +101,10 @@ class RelayBuilder
 
         if ($getArrayCopy) {
             return $queue->getArrayCopy();
+        }
+
+        if ($queue instanceof Traversable) {
+            return iterator_to_array($queue);
         }
 
         throw new InvalidArgumentException();

--- a/tests/RelayBuilderTest.php
+++ b/tests/RelayBuilderTest.php
@@ -3,6 +3,7 @@ namespace Relay;
 
 use ArrayObject;
 use InvalidArgumentException;
+use Traversable;
 
 class RelayBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,11 +26,28 @@ class RelayBuilderTest extends \PHPUnit_Framework_TestCase
         $queue = new ArrayObject([]);
         $relay = $this->relayBuilder->newInstance($queue);
         $this->assertInstanceOf('Relay\Relay', $relay);
+
+        $queue = $this->getMock(ArrayObject::class);
+        $queue
+            ->expects($this->once())
+            ->method('getArrayCopy')
+            ->willReturn([]);
+
+        $relay = $this->relayBuilder->newInstance($queue);
+        $this->assertInstanceOf('Relay\Relay', $relay);
     }
 
     public function testGetArrayCopyInterface()
     {
         $queue = new FakeQueue();
+        $relay = $this->relayBuilder->newInstance($queue);
+        $this->assertInstanceOf('Relay\Relay', $relay);
+    }
+
+    public function testTraversable()
+    {
+        $queue = $this->getMock(Traversable::class);
+
         $relay = $this->relayBuilder->newInstance($queue);
         $this->assertInstanceOf('Relay\Relay', $relay);
     }


### PR DESCRIPTION
The correct way to detect for objects that can be used as iterators is
against the `Traversable` interface. This works for `ArrayObject` and
any other objects that implement iterator interfaces.

http://php.net/traversable

Fixes #21
