### PR TITLE
Change request type hint to server request

### DIFF
--- a/src/Last.php
+++ b/src/Last.php
@@ -10,7 +10,7 @@
  */
 namespace Relay;
 
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -26,7 +26,7 @@ class Last implements MiddlewareInterface
      *
      * Bounces the Response back through the middleware queue.
      *
-     * @param RequestInterface $request The request.
+     * @param ServerRequestInterface $request The request.
      *
      * @param ResponseInterface $response The response.
      *
@@ -37,7 +37,7 @@ class Last implements MiddlewareInterface
      *
      */
     public function __invoke(
-        RequestInterface $request,
+        ServerRequestInterface $request,
         ResponseInterface $response,
         callable $next
     ) {

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -10,7 +10,7 @@
  */
 namespace Relay;
 
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -40,7 +40,7 @@ interface MiddlewareInterface
      *
      */
     public function __invoke(
-        RequestInterface $request,
+        ServerRequestInterface $request,
         ResponseInterface $response,
         callable $next
     );

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -10,7 +10,7 @@
  */
 namespace Relay;
 
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -47,14 +47,14 @@ class Relay
      *
      * Dispatches to a new Runner.
      *
-     * @param RequestInterface $request The request.
+     * @param ServerRequestInterface $request The request.
      *
      * @param ResponseInterface $response The response.
      *
      * @return ResponseInterface
      *
      */
-    public function __invoke(RequestInterface $request, ResponseInterface $response)
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
         $runner = $this->runnerFactory->newInstance();
         return $runner($request, $response);
@@ -64,14 +64,14 @@ class Relay
      *
      * Dispatches to a new Runner; essentially an alias to `__invoke()`.
      *
-     * @param RequestInterface $request The request.
+     * @param ServerRequestInterface $request The request.
      *
      * @param ResponseInterface $response The response.
      *
      * @return ResponseInterface
      *
      */
-    public function run(RequestInterface $request, ResponseInterface $response)
+    public function run(ServerRequestInterface $request, ResponseInterface $response)
     {
         return $this($request, $response);
     }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -10,7 +10,7 @@
  */
 namespace Relay;
 
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -59,14 +59,14 @@ class Runner
      *
      * Calls the next entry in the queue.
      *
-     * @param RequestInterface $request The request.
+     * @param ServerRequestInterface $request The request.
      *
      * @param ResponseInterface $response The response.
      *
      * @return ResponseInterface
      *
      */
-    public function __invoke(RequestInterface $request, ResponseInterface $response)
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
         $entry = array_shift($this->queue);
         $middleware = $this->resolve($entry);
@@ -77,14 +77,14 @@ class Runner
      *
      * Calls the next entry in the queue; essentially an alias to `__invoke()`.
      *
-     * @param RequestInterface $request The request.
+     * @param ServerRequestInterface $request The request.
      *
      * @param ResponseInterface $response The response.
      *
      * @return ResponseInterface
      *
      */
-    public function run(RequestInterface $request, ResponseInterface $response)
+    public function run(ServerRequestInterface $request, ResponseInterface $response)
     {
         return $this($request, $response);
     }

--- a/tests/FakeMiddleware.php
+++ b/tests/FakeMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 namespace Relay;
 
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class FakeMiddleware implements MiddlewareInterface
@@ -9,7 +9,7 @@ class FakeMiddleware implements MiddlewareInterface
     public static $count = 0;
 
     public function __invoke(
-        RequestInterface $request,
+        ServerRequestInterface $request,
         ResponseInterface $response,
         callable $next
     ) {


### PR DESCRIPTION
Type hinting against `RequestInterface` is often insufficient when
working with server applications which will require access to query
strings, uploaded files, etc.

Fixes #25
