### PR TITLE
Allow to use Runner as a middleware component

### DIFF
--- a/tests/FakeMiddleware.php
+++ b/tests/FakeMiddleware.php
@@ -13,9 +13,11 @@ class FakeMiddleware implements MiddlewareInterface
         ResponseInterface $response,
         callable $next
     ) {
-        $response->getBody()->write(++ static::$count);
+        $n = ++ static::$count;
+
+        $response->getBody()->write("{$n}>");
         $response = $next($request, $response);
-        $response->getBody()->write(++ static::$count);
+        $response->getBody()->write("<{$n}");
         return $response;
     }
 }

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -23,7 +23,7 @@ class RelayTest extends \PHPUnit_Framework_TestCase
             new Response()
         );
         $actual = (string) $response->getBody();
-        $this->assertSame('123456', $actual);
+        $this->assertSame('1>2>3><3<2<1', $actual);
 
         // relay again
         $response = $relay(
@@ -31,6 +31,6 @@ class RelayTest extends \PHPUnit_Framework_TestCase
             new Response()
         );
         $actual = (string) $response->getBody();
-        $this->assertSame('789101112', $actual);
+        $this->assertSame('4>5>6><6<5<4', $actual);
     }
 }

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -21,7 +21,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         );
 
         $actual = (string) $response->getBody();
-        $this->assertSame('123456', $actual);
+        $this->assertSame('1>2>3><3<2<1', $actual);
     }
 
     public function testWithResolver()
@@ -41,7 +41,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         );
 
         $actual = (string) $response->getBody();
-        $this->assertSame('123456', $actual);
+        $this->assertSame('1>2>3><3<2<1', $actual);
     }
 
     public function testUnexpectedValue()
@@ -81,6 +81,6 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         );
 
         $actual = (string) $response->getBody();
-        $this->assertSame('12345678910', $actual);
+        $this->assertSame('1>2>3>4>5><5<4<3<2<1', $actual);
     }
 }

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -58,4 +58,29 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             new Response()
         );
     }
+
+    public function testWithSubRunner()
+    {
+        FakeMiddleware::$count = 0;
+
+        $runner = new Runner([
+            new Runner([
+                new FakeMiddleware(),
+                new FakeMiddleware(),
+                new Runner([
+                    new FakeMiddleware(),
+                    new FakeMiddleware(),
+                ]),
+            ]),
+            new FakeMiddleware()
+        ]);
+
+        $response = $runner(
+            ServerRequestFactory::fromGlobals(),
+            new Response()
+        );
+
+        $actual = (string) $response->getBody();
+        $this->assertSame('12345678910', $actual);
+    }
 }


### PR DESCRIPTION
Related with #30.

This allows to use the middleware dispatcher as an inner component of other middleware dispatcher.
To do that, I've moved the logic of `__invoke` to `run` and serve the $next callable instead Last, so the execution order of all components are preserved.

Any suggestion is welcome 🍰
