### PR TITLE
Accept all types of callbacks

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -36,6 +36,6 @@ class Runner extends RequestHandler
             return $middleware->process($request, $this);
         }
 
-        return $middleware($request, $this);
+        return call_user_func($middleware, $request, $this);
     }
 }


### PR DESCRIPTION
Hello, thank you for your implementation of PSR-15.
I propose this modification to use callable type when you set a function as middleware.
In old way you can only pass function name or Closure.
With this PR, you can use **callable** (function name is callable) & **Closure**.
It's very usefull when you want call a method.
Thank you.