### PR TITLE
Added $resolver definition

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -24,6 +24,12 @@ use TypeError;
  */
 abstract class RequestHandler implements RequestHandlerInterface
 {
+    
+    /**
+     * @var callable
+     */
+    protected $resolver;
+    
     /**
      *
      * Constructor.


### PR DESCRIPTION
Is there a reason not to define $resolver inside this abstract class?
I think it's more readable for people implementing it to avoid using dynamic properties.

I used "protected" since it's going to be referred inside concrete implementations of this Handler (like in Runner class).

Thank you