### PR TITLE
Throw a more obvious error when the queue is empty on construction

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -11,11 +11,12 @@
 namespace Relay;
 
 use InvalidArgumentException;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Traversable;
 use TypeError;
+use function count;
 
 /**
  *
@@ -51,7 +52,7 @@ abstract class RequestHandler implements RequestHandlerInterface
             throw new TypeError('\$queue must be array or Traversable.');
         }
 
-        if (empty($queue)) {
+        if (count($queue) === 0) {
             throw new InvalidArgumentException('$queue cannot be empty');
         }
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -10,6 +10,7 @@
  */
 namespace Relay;
 
+use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -48,6 +49,10 @@ abstract class RequestHandler implements RequestHandlerInterface
     {
         if (! is_iterable($queue)) {
             throw new TypeError('\$queue must be array or Traversable.');
+        }
+
+        if (empty($queue)) {
+            throw new InvalidArgumentException('$queue cannot be empty');
         }
 
         $this->queue = $queue;

--- a/tests/RelayBuilderTest.php
+++ b/tests/RelayBuilderTest.php
@@ -4,6 +4,7 @@ namespace Relay;
 use ArrayObject;
 use InvalidArgumentException;
 use Traversable;
+use Zend\Diactoros\ServerRequestFactory;
 
 class RelayBuilderTest extends \PHPUnit\Framework\TestCase
 {
@@ -16,14 +17,18 @@ class RelayBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testArray()
     {
-        $queue = [];
+        $queue = [
+            new FakeMiddleware()
+        ];
         $relay = $this->relayBuilder->newInstance($queue);
         $this->assertInstanceOf('Relay\Relay', $relay);
     }
 
     public function testArrayObject()
     {
-        $queue = new ArrayObject([]);
+        $queue = new ArrayObject([
+            new FakeMiddleware()
+        ]);
         $relay = $this->relayBuilder->newInstance($queue);
         $this->assertInstanceOf('Relay\Relay', $relay);
     }
@@ -40,5 +45,13 @@ class RelayBuilderTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException('TypeError');
         $this->relayBuilder->newInstance('bad argument');
+    }
+
+    public function testEmptyQueue()
+    {
+        $this->expectException(InvalidArgumentException::CLASS);
+        $this->expectExceptionMessage('$queue cannot be empty');
+
+        $this->relayBuilder->newInstance([]);
     }
 }

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -2,6 +2,7 @@
 namespace Relay;
 
 use ArrayObject;
+use InvalidArgumentException;
 use TypeError;
 use Zend\Diactoros\ServerRequestFactory;
 use Zend\Diactoros\Response;
@@ -60,6 +61,15 @@ class RelayTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(TypeError::CLASS);
         $relay = new Relay('bad');
+    }
+
+    public function testEmptyQueue()
+    {
+        $this->expectException(InvalidArgumentException::CLASS);
+        $this->expectExceptionMessage('$queue cannot be empty');
+
+        $relay = new Relay([]);
+        $relay->handle(ServerRequestFactory::fromGlobals());
     }
 
     public function testResolverEntries()

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -68,8 +68,7 @@ class RelayTest extends \PHPUnit\Framework\TestCase
         $this->expectException(InvalidArgumentException::CLASS);
         $this->expectExceptionMessage('$queue cannot be empty');
 
-        $relay = new Relay([]);
-        $relay->handle(ServerRequestFactory::fromGlobals());
+        new Relay([]);
     }
 
     public function testResolverEntries()


### PR DESCRIPTION
This provides clearer language for the error raised when an empty queue is passed into Relay on construction. Should fix #42.

@urugator and @niden, mind checking this one out?