### PR TITLE
Fix next not callable

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -38,4 +38,9 @@ class Runner extends RequestHandler
 
         return $middleware($request, $this);
     }
+
+    public function __invoke(ServerRequestInterface $request) : ResponseInterface
+    {
+        return $this->handle($request);
+    }
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -13,6 +13,8 @@ namespace Relay;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use RuntimeException;
+use function is_callable;
 
 /**
  *
@@ -36,7 +38,14 @@ class Runner extends RequestHandler
             return $middleware->process($request, $this);
         }
 
-        return $middleware($request, $this);
+        if (is_callable($middleware)) {
+            return $middleware($request, $this);
+        }
+
+        throw new RuntimeException(
+            "Invalid middleware queue entry: {$middleware}. Middleware must either be callable or implement " .
+            MiddlewareInterface::class . '.'
+        );
     }
 
     public function __invoke(ServerRequestInterface $request) : ResponseInterface

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -5,6 +5,7 @@ use ArrayObject;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 use TypeError;
 use Zend\Diactoros\ServerRequestFactory;
 use Zend\Diactoros\Response;
@@ -62,7 +63,7 @@ class RelayTest extends \PHPUnit\Framework\TestCase
     public function testBadQueue()
     {
         $this->expectException(TypeError::CLASS);
-        $relay = new Relay('bad');
+        new Relay('bad');
     }
 
     public function testEmptyQueue()
@@ -71,6 +72,17 @@ class RelayTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('$queue cannot be empty');
 
         new Relay([]);
+    }
+
+    public function testQueueWithInvalidEntry()
+    {
+        $this->expectException(RuntimeException::CLASS);
+        $this->expectExceptionMessage(
+            "Invalid middleware queue entry: bad. Middleware must either be callable or implement Psr\Http\Server\MiddlewareInterface."
+        );
+
+        $relay = new Relay(['bad']);
+        $relay->handle(ServerRequestFactory::fromGlobals());
     }
 
     public function testResolverEntries()


### PR DESCRIPTION
Fix #41 by making `Runner` invokable, thereby actually making the Callable Middleware documentation valid:

```php
function (
    Request $request, // the request
    callable $next // the next middleware or handler
) : Response {
    // ...
}
```

This PR also adds a more obvious exception when a resolved queue entry is not callable or does not implement `MiddlewareInterface`, as raised in https://github.com/relayphp/Relay.Relay/pull/43#issuecomment-500202529.