### PR TITLE
Declare implicit dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,16 @@
         }
     },
     "require-dev": {
-        "zendframework/zend-diactoros": "~1.0",
+        "phpunit/phpunit": "~7.0",
         "psr/http-server-middleware": "~1.0",
-        "phpunit/phpunit": "~7.0"
+        "zendframework/zend-diactoros": "~1.0"
     },
     "autoload-dev": {
         "psr-4": {
             "Relay\\": "tests/"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "psr/http-server-handler": "~1.0",
         "psr/http-server-middleware": "^1.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~7.0",
+        "zendframework/zend-diactoros": "~1.0"
+    },
     "autoload": {
         "psr-4": {
             "Relay\\": "src/"
         }
-    },
-    "require-dev": {
-        "phpunit/phpunit": "~7.0",
-        "zendframework/zend-diactoros": "~1.0"
     },
     "autoload-dev": {
         "psr-4": {
@@ -37,5 +37,8 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "provide": {
+        "psr/http-server-handler-implementation": "1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=7.1",
         "psr/http-message": "~1.0",
-        "psr/http-server-handler": "~1.0"
+        "psr/http-server-handler": "~1.0",
+        "psr/http-server-middleware": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +28,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",
-        "psr/http-server-middleware": "~1.0",
         "zendframework/zend-diactoros": "~1.0"
     },
     "autoload-dev": {


### PR DESCRIPTION
Explicitly declare that Relay depends on https://github.com/php-fig/http-server-middleware, since it does. Also note that this library provides an implementation of https://github.com/php-fig/http-server-handler.