### PR TITLE
Add support for running RequestHandlerInterface queue items

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -10,9 +10,10 @@
  */
 namespace Relay;
 
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  *
@@ -34,6 +35,10 @@ class Runner extends RequestHandler
 
         if ($middleware instanceof MiddlewareInterface) {
             return $middleware->process($request, $this);
+        }
+
+        if ($middleware instanceof RequestHandlerInterface) {
+            return $middleware->handle($request);
         }
 
         return $middleware($request, $this);

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -84,4 +84,18 @@ class RelayTest extends \PHPUnit\Framework\TestCase
 
         $this->assertRelay(new Relay($queue, $resolver));
     }
+
+    public function testRequestHandlerInQueue()
+    {
+        $queue = [
+            new FakeMiddleware(),
+            new FakeMiddleware(),
+            new FakeMiddleware(),
+            $this->responder,
+        ];
+
+        $requestHandler = new Relay($queue);
+
+        $this->assertRelay(new Relay([$requestHandler]));
+    }
 }


### PR DESCRIPTION
This treats RequestHandlerInterface as middleware, which allows Relay to act as a master queue for other PSR-15 compatible sub-queues.